### PR TITLE
update deps + loosen some requirements 

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ reuse_port = []
 
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["ifaces"] }
-tokio = { version = "1.15.0", features = ["full"] }
-socket2 = { version = "0.4.2", features = ["all"] }
-log = "0.4.14"
-thiserror = "1.0.30"
+tokio = { version = "1.19", features = ["full"] }
+socket2 = { version = "0.4.4", features = ["all"] }
+log = "0.4"
+thiserror = "1.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"
 chrono = "0.4.19"
-clap = "2.34.0"
+clap = "3.2.6"
 
 [[example]]
 name = "mdns_query"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = [ "reuse_port" ]
 reuse_port = []
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["ifaces"] }
+util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["ifaces"] }
 tokio = { version = "1.19", features = ["full"] }
 socket2 = { version = "0.4.4", features = ["all"] }
 log = "0.4"

--- a/src/message/header.rs
+++ b/src/message/header.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 // Header is a representation of a DNS message header.
-#[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Header {
     pub id: u16,
     pub response: bool,
@@ -54,7 +54,7 @@ impl Header {
     }
 }
 
-#[derive(Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq)]
 pub enum Section {
     NotStarted = 0,
     Header = 1,

--- a/src/message/message_test.rs
+++ b/src/message/message_test.rs
@@ -44,7 +44,7 @@ fn small_test_msg() -> Result<Message> {
         }],
         additionals: vec![Resource {
             header: ResourceHeader {
-                name: name,
+                name,
                 typ: DnsType::A,
                 class: DNSCLASS_INET,
                 ..Default::default()
@@ -201,7 +201,7 @@ fn large_test_msg() -> Result<Message> {
             },
             Resource {
                 header: ResourceHeader {
-                    name: name,
+                    name,
                     typ: DnsType::Txt,
                     class: DNSCLASS_INET,
                     ..Default::default()

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -22,7 +22,7 @@ use std::fmt;
 // Message formats
 
 // A Type is a type of DNS request and response.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DnsType {
     // ResourceHeader.Type and question.Type
     A = 1,
@@ -167,7 +167,7 @@ impl DnsClass {
 pub type OpCode = u16;
 
 // An RCode is a DNS response status code.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RCode {
     // Message.Rcode
     Success = 0,

--- a/src/message/name.rs
+++ b/src/message/name.rs
@@ -7,7 +7,7 @@ const NAME_LEN: usize = 255;
 
 // A Name is a non-encoded domain name. It is used instead of strings to avoid
 // allocations.
-#[derive(Default, PartialEq, Debug, Clone)]
+#[derive(Default, PartialEq, Eq, Debug, Clone)]
 pub struct Name {
     pub data: String,
 }

--- a/src/message/question.rs
+++ b/src/message/question.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 // A question is a DNS query.
-#[derive(Default, Debug, PartialEq, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct Question {
     pub name: Name,
     pub typ: DnsType,

--- a/src/message/resource/a.rs
+++ b/src/message/resource/a.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::message::packer::*;
 
 // An AResource is an A Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct AResource {
     pub a: [u8; 4],
 }

--- a/src/message/resource/aaaa.rs
+++ b/src/message/resource/aaaa.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::message::packer::*;
 
 // An AAAAResource is an aaaa Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct AaaaResource {
     pub aaaa: [u8; 16],
 }

--- a/src/message/resource/cname.rs
+++ b/src/message/resource/cname.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::message::name::*;
 
 // A cnameresource is a cname Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct CnameResource {
     pub cname: Name,
 }

--- a/src/message/resource/mod.rs
+++ b/src/message/resource/mod.rs
@@ -103,7 +103,7 @@ impl Resource {
 
 // A ResourceHeader is the header of a DNS resource record. There are
 // many types of DNS resource records, but they all share the same header.
-#[derive(Clone, Default, PartialEq, Debug)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct ResourceHeader {
     // Name is the domain name for which this resource record pertains.
     pub name: Name,

--- a/src/message/resource/mx.rs
+++ b/src/message/resource/mx.rs
@@ -4,7 +4,7 @@ use crate::message::name::*;
 use crate::message::packer::*;
 
 // An MXResource is an mx Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct MxResource {
     pub pref: u16,
     pub mx: Name,

--- a/src/message/resource/ns.rs
+++ b/src/message/resource/ns.rs
@@ -3,7 +3,7 @@ use crate::error::Result;
 use crate::message::name::*;
 
 // An NSResource is an NS Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct NsResource {
     pub ns: Name,
 }

--- a/src/message/resource/opt.rs
+++ b/src/message/resource/opt.rs
@@ -7,7 +7,7 @@ use crate::message::packer::*;
 //
 // The pseudo resource record is part of the extension mechanisms for DNS
 // as defined in RFC 6891.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct OptResource {
     pub options: Vec<DnsOption>,
 }
@@ -16,7 +16,7 @@ pub struct OptResource {
 //
 // The message option is part of the extension mechanisms for DNS as
 // defined in RFC 6891.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct DnsOption {
     pub code: u16, // option code
     pub data: Vec<u8>,

--- a/src/message/resource/ptr.rs
+++ b/src/message/resource/ptr.rs
@@ -3,7 +3,7 @@ use crate::error::Result;
 use crate::message::name::*;
 
 // A PTRResource is a PTR Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct PtrResource {
     pub ptr: Name,
 }

--- a/src/message/resource/soa.rs
+++ b/src/message/resource/soa.rs
@@ -4,7 +4,7 @@ use crate::message::name::*;
 use crate::message::packer::*;
 
 // An SOAResource is an SOA Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct SoaResource {
     pub ns: Name,
     pub mbox: Name,

--- a/src/message/resource/srv.rs
+++ b/src/message/resource/srv.rs
@@ -4,7 +4,7 @@ use crate::message::name::*;
 use crate::message::packer::*;
 
 // An SRVResource is an SRV Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct SrvResource {
     pub priority: u16,
     pub weight: u16,

--- a/src/message/resource/txt.rs
+++ b/src/message/resource/txt.rs
@@ -3,7 +3,7 @@ use crate::error::*;
 use crate::message::packer::*;
 
 // A TXTResource is a txt Resource record.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct TxtResource {
     pub txt: Vec<String>,
 }


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions